### PR TITLE
Add Harmony support to jsx-loader unconditionally

### DIFF
--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -11,7 +11,7 @@ module.exports = function(options) {
 	};
 	var loaders = {
 		"coffee": "coffee-redux-loader",
-		"jsx": options.hotComponents ? ["react-hot-loader", "jsx-loader?harmony"] : "jsx-loader",
+		"jsx": options.hotComponents ? ["react-hot-loader", "jsx-loader?harmony"] : "jsx-loader?harmony",
 		"json": "json-loader",
 		// "js": {
 			// loader: "6to5-loader",


### PR DESCRIPTION
e98890dc3e0633d210ae68c803d970b9336788eb  added `var { stores } = this.context;`, which requires harmony parsing for the destructuring