### PR TITLE
use harmony jsx transform for all builds

### DIFF
--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -11,7 +11,7 @@ module.exports = function(options) {
 	};
 	var loaders = {
 		"coffee": "coffee-redux-loader",
-		"jsx": options.hotComponents ? ["react-hot-loader", "jsx-loader?harmony"] : "jsx-loader",
+		"jsx": options.hotComponents ? ["react-hot-loader", "jsx-loader?harmony"] : "jsx-loader?harmony",
 		"json": "json-loader",
 		// "js": {
 			// loader: "6to5-loader",


### PR DESCRIPTION
All non-"hot" build modes are currently failing compilation, since the Harmony transform is not being applied.

"Faulty" line:
app/Application/index.js:36:
`var { stores } = this.context;`