### PR TITLE
Don't make up assets that don't exist

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -133,8 +133,7 @@ module.exports = function(options) {
 				callback(null, listsDb.get(item.id, []));
 			}
 		}, SCRIPT_URL, STYLE_URL, COMMONS_URL, function(err, html) {
-			res.contentType = "text/html; charset=utf8";
-			res.end(html);
+			res.send(404);
 		});
 	});
 


### PR DESCRIPTION
I think 404s are a useful debugging aid, so I'm wondering why something like this PR isn't what one should have.