### PR TITLE
Change port number to make production server work

### DIFF
--- a/lib/server-production.js
+++ b/lib/server-production.js
@@ -1,5 +1,5 @@
 require("./server")({
 	prerender: true,
 	separateStylesheet: true,
-	defaultPort: 80
+	defaultPort: 8000
 });


### PR DESCRIPTION
I get the error "listen EACCES" when running "npm run start".

According to this [SO post](http://stackoverflow.com/questions/18947356/node-js-app-cant-run-on-port-80-even-though-theres-no-other-process-blocking-t), I needed to run the production server under a port over 1024 which does not require root access.

Not sure if you want to change the port number here to make "npm run start" work or add a note to the README production step to tell people that the error they see is related to a permission problem and not something in the server.js file. Let me know if I understand this error correctly. Thanks.