### PR TITLE
Added NotFound page.

### DIFF
--- a/app/NotFound/index.jsx
+++ b/app/NotFound/index.jsx
@@ -1,0 +1,10 @@
+var React = require("react");
+
+module.exports = React.createClass({
+	render: function() {
+		return <div>
+			<h2>Not found</h2>
+			<p>The page you requested was not found.</p>
+		</div>;
+	}
+});

--- a/app/mainRoutes.jsx
+++ b/app/mainRoutes.jsx
@@ -2,6 +2,7 @@ var React = require("react");
 var Router = require("react-router");
 var Route = Router.Route;
 var DefaultRoute = Router.DefaultRoute;
+var NotFoundRoute = Router.NotFoundRoute;
 
 // polyfill
 if(!Object.assign)
@@ -16,5 +17,6 @@ module.exports = (
 		<Route name="todoitem" path="/todo/:item" handler={require("./TodoItem")} />
 		<Route name="home" path="/home" handler={require("./Home")} />
 		<DefaultRoute handler={require("./Home")} />
+		<NotFoundRoute handler={require("./NotFound")} />
 	</Route>
 );


### PR DESCRIPTION
This indicates the route was not found.

Note: the todolist route still tries to match any root map. So `http://localhost:8080/notexisting` shows an (empty) TodoList page, and `http://localhost:8080/notexisting/bar` shows the NotFound page.
I fixed that in PR https://github.com/webpack/react-starter/pull/49 by adding subroute for TodoList and TodoItem.