### PR TITLE
Fixes #78

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -66,7 +66,7 @@ module.exports = function(options) {
 	});
 
 
-	var port = +(process.env.PORT || options.defaultPort || 8080);
+	var port = process.env.PORT || options.defaultPort || 8080;
 	app.listen(port, function() {
 		console.log("Server listening on port " + port);
 	});


### PR DESCRIPTION
Removes the cast to a number on the port because a string is valid and the port can be a filename pointing to a unix socket.
