### PR TITLE
Remove assign entry.loaders for any value type

### DIFF
--- a/config/loadersByExtension.js
+++ b/config/loadersByExtension.js
@@ -11,8 +11,7 @@ module.exports = function loadersByExtension(obj) {
 		var value = obj[key];
 		var entry = {
 			extensions: exts,
-			test: extsToRegExp(exts),
-			loaders: value
+			test: extsToRegExp(exts)
 		};
 		if(Array.isArray(value)) {
 			entry.loaders = value;


### PR DESCRIPTION
I think that only value is type of array need a `loaders` property on entry, so I remove the line.