### PR TITLE
Work around Windows file path length restrictions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /build
 .vagrant
+npm-debug.log*

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,7 @@ set -o xtrace
 %s
 
 export DEBIAN_FRONTEND=noninteractive
-curl -sL https://deb.nodesource.com/setup_iojs_1.x | sudo bash -
+curl -sL https://deb.nodesource.com/setup_iojs_1.x | bash -
 apt-get install -y iojs build-essential
 
 exec sudo -i -u vagrant /bin/bash -- << EOF

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,23 +1,31 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-_script = <<SCRIPT
+_SCRIPT = <<SCRIPT
 set -o errexit
 set -o pipefail
 set -o nounset
 shopt -s failglob
 set -o xtrace
 
+%s
+
 export DEBIAN_FRONTEND=noninteractive
 curl -sL https://deb.nodesource.com/setup_iojs_1.x | sudo bash -
 apt-get install -y iojs
-
 
 exec sudo -i -u vagrant /bin/bash -- << EOF
 cd /vagrant
 npm install
 
 EOF
+SCRIPT
+
+_SCRIPT_WIN = <<SCRIPT
+rm -Rf /vagrant/node_modules
+mkdir -p /var/tmp/vagrant/node_modules
+chown vagrant:vagrant /var/tmp/vagrant/node_modules
+ln -s /var/tmp/vagrant/node_modules /vagrant/node_modules
 SCRIPT
 
 Vagrant.configure("2") do |config|
@@ -28,7 +36,15 @@ Vagrant.configure("2") do |config|
     v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
   end
 
+  # Work around Windows file path length restrictions
+  if Vagrant::Util::Platform.windows?
+    _script = _SCRIPT % _SCRIPT_WIN
+  else
+    _script = _SCRIPT % ""
+  end
+    
   config.vm.provision "shell", inline: _script
+    
   config.vm.network "forwarded_port", guest: 8080, host: 8080
   config.vm.network "forwarded_port", guest: 2992, host: 2992
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ set -o xtrace
 
 export DEBIAN_FRONTEND=noninteractive
 curl -sL https://deb.nodesource.com/setup_iojs_1.x | sudo bash -
-apt-get install -y iojs
+apt-get install -y iojs build-essential
 
 exec sudo -i -u vagrant /bin/bash -- << EOF
 cd /vagrant


### PR DESCRIPTION
Use a symlink for /vagrant/node_moldules that points out of the shared folder on windows to work around the path length restrictions on windows
