### PR TITLE
windows workflow improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ vagrant ssh
 cd /vagrant
 ```
 
+NOTE:
+    
+    On Windows `vagrant up` should be run with
+    administrative privileges (e.g. from an elevated
+    command prompt opened via the right click `Run
+    as administrator` context menu action) to allow
+    symlinking.  Otherwise the box will fail! The
+    included `vagrant.bat` handles this automatically.
+    If an ssh executable is not found on the system path,
+    and git is installed, `vagrant.bat` will attempt to
+    fallback to the ssh executable installed with git via
+    the included `vagrant-bin/ssh.bat` script.
+
 ## Development server
 
 ``` text

--- a/vagrant-bin/ssh.bat
+++ b/vagrant-bin/ssh.bat
@@ -1,0 +1,59 @@
+@ECHO OFF
+
+SETLOCAL EnableDelayedExpansion
+
+REM // MUST SPECIFY ssh AS ssh.exe SO THAT THIS FILE CALLS THE ACTUAL ssh INSTEAD
+REM // OF CALLING ITSELF RECURSIVELY FOREVER
+set WHERE_SSH_CMD=where.exe ssh.exe
+
+REM set WHERE_SSH_CMD=where.exe ForceSshExist.exe
+REM set WHERE_SSH_CMD=where.exe ForceSshDoesNotExist.exe
+REM echo WHERE_SSH_CMD: %WHERE_SSH_CMD%
+
+FOR /F "tokens=* USEBACKQ" %%F IN (`!WHERE_SSH_CMD! 2^>NUL`) DO (
+    SET SSH_PATH=%%F
+)
+
+REM ECHO SSH_PATH: "!SSH_PATH!"
+
+IF "!SSH_PATH!" EQU "" (
+
+    set WHERE_GIT_CMD=where.exe git
+    
+    REM set WHERE_GIT_CMD=where.exe ForceGitExist
+    REM set WHERE_GIT_CMD=where.exe ForceGitDoesNotExist
+    REM echo WHERE_GIT_CMD: !WHERE_GIT_CMD!
+    
+    FOR /F "tokens=* USEBACKQ" %%F IN (`!WHERE_GIT_CMD! 2^>NUL`) DO (
+        SET GIT_PATH=%%F
+    )
+    
+    IF NOT EXIST "!GIT_PATH!" (
+        ECHO !WHERE_GIT_CMD!
+        ECHO git installation not found. cannot use its bundled ssh executable
+        EXIT /B
+    )
+    
+    REM echo GIT_PATH: !GIT_PATH!
+    
+    set REL_BIN_DIR=!GIT_PATH!\..\..\bin
+    
+    REM echo REL_BIN_DIR: !REL_BIN_DIR!
+    
+    pushd !REL_BIN_DIR!
+    
+    set ABS_BIN_DIR=!CD!
+    
+    popd
+    
+    REM echo ABS_BIN_DIR: !ABS_BIN_DIR!
+    
+    SET PATH=!ABS_BIN_DIR!;!PATH!
+    
+    REM echo SET PATH AS: !PATH!
+
+)
+
+@ECHO ON
+
+@ssh.exe %*

--- a/vagrant.bat
+++ b/vagrant.bat
@@ -1,0 +1,116 @@
+@ECHO OFF
+
+
+REM // AUTOMATIC PRIVILEGE ELEVATION CODE RESEARCHED FROM VARIOUS SOURCES USING A PUBLIC SEARCH ENGINE.
+REM // http://stackoverflow.com/a/12264592/319862
+REM // http://stackoverflow.com/a/28467343/319862
+REM // http://ss64.com/vb/syntax-elevate.html
+
+
+setlocal EnableDelayedExpansion
+
+set ABS_DIR=%~dp0
+set ABS_PATH=%~f0
+set DO_ELEVATE=""
+set NEEDS_ELEVATE="1"
+set IS_ELEVATED="0"
+set PROXY_ARGS=%*
+set CLOSE_WINDOW="0"
+
+if "%1" == "-h" (
+    set NEEDS_ELEVATE="0"
+)
+if "%1" == "--help" (
+    set NEEDS_ELEVATE="0"
+)
+if "%1" == "-v" (
+    set NEEDS_ELEVATE="0"
+)
+if "%1" == "--version" (
+    set NEEDS_ELEVATE="0"
+)
+if "%1" == "version" (
+    set NEEDS_ELEVATE="0"
+)
+if "%1" == "plugin" (
+    set NEEDS_ELEVATE="0"
+)
+
+:: Check if we are elevated
+FSUTIL dirty query %systemdrive% >nul
+If !errorLevel! EQU 0 (
+   set IS_ELEVATED="1"
+)
+
+::Remove the elevation tag
+IF '%1'=='ELEV' (
+    for /f "tokens=1,* delims= " %%a in ("%*") do set PROXY_ARGS=%%b
+    
+    IF !IS_ELEVATED! EQU "0" (
+        ECHO ISSUE ELEVATING PRIVILEGES. CANNOT PROCEED.
+        PAUSE
+        EXIT /B
+    )
+    
+    set CLOSE_WINDOW="1"
+)
+
+IF !IS_ELEVATED! EQU "0" IF !NEEDS_ELEVATE! EQU "1" (
+    set DO_ELEVATE="1"
+)
+
+set "QUOTED_PATH=%~f0"
+set "QUOTED_ARGS=ELEV"
+
+::Add quotes to the batch path, if needed
+set "script=%0"
+set script=%script:"=%
+IF '%0'=='!script!' ( GOTO PathQuotesDone )
+    set "QUOTED_PATH=""%QUOTED_PATH%"""
+:PathQuotesDone
+
+::Add quotes to the arguments, if needed.
+:ArgLoop
+IF '%1'=='' ( GOTO EndArgLoop ) else ( GOTO AddArg )
+    :AddArg
+    set "arg=%1"
+    set arg=%arg:"=%
+    IF '%1'=='!arg!' ( GOTO NoQuotes )
+        set "QUOTED_ARGS=%QUOTED_ARGS% "%1""
+        GOTO QuotesDone
+        :NoQuotes
+        set "QUOTED_ARGS=%QUOTED_ARGS% %1"
+    :QuotesDone
+    shift
+    GOTO ArgLoop
+:EndArgLoop
+
+
+if !DO_ELEVATE! EQU "1" (
+    :getfilename
+    SET FILENAME="%temp%\VAGRANT-BAT-ELEVATE-!RANDOM!!RANDOM!!RANDOM!.vbs"
+    IF EXIST "!FILENAME!" goto :getfilename
+    ::Create and run the vb script to elevate the batch file
+    ECHO CreateObject^("Scripting.FileSystemObject"^).DeleteFile^(Wscript.ScriptFullName^) > "!FILENAME!"
+    ECHO CreateObject^("Shell.Application"^).ShellExecute "cmd", "/k ""!QUOTED_PATH! !QUOTED_ARGS!""", "", "runas", 1 >> "!FILENAME!"
+    REM ECHO "!FILENAME!"
+    "!FILENAME!"
+    EXIT /B
+)
+
+
+REM // ENSURE CWD IS SCRIPT DIR - ELEVATING CHANGES CWD
+cd /d %ABS_DIR%
+
+pushd vagrant-bin
+set PATH=%CD%;%PATH%
+popd
+
+@ECHO ON
+@vagrant.exe !PROXY_ARGS!
+
+@ECHO OFF
+IF !CLOSE_WINDOW! EQU "1" (
+    PAUSE
+    EXIT
+)


### PR DESCRIPTION
on windows automatically elevate to admin privileges if needed and attempt to use git's bundled ssh if ssh not found

this makes the `vagrant up` and `vagrant ssh` commands work without requiring extra effort from the user on a windows host

Windows doesn't ship with a compatible ssh executable.  Git installer on windows doesn't add git bin dir to the system path by default because it causes conflicts with windows built ins.  The batch script makes git's bundled ssh usable in the vagrant context in this case.  It defaults to ssh on the path if there is one

The vagrant.bat wrapper handles automatic privilege escalation which is necessary on windows to have the permissions to create symlinks in the shared folder.

This currently uses the command prompt for windows it opens.  A future commit could use the command prompt or power shell depending on which the user is calling from.
